### PR TITLE
Fix pagination return value in request method

### DIFF
--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -185,9 +185,7 @@ module Oktakit
       uri = URI::DEFAULT_PARSER.escape("/api/v1" + path.to_s)
       @last_response = resp = sawyer_agent.call(method, uri, data, options)
 
-      response = [resp.data, resp.status]
-      response << absolute_to_relative_url(resp.rels[:next]) if paginate
-      response
+      [resp.data, resp.status, paginate ? absolute_to_relative_url(resp.rels[:next]) : nil]
     end
 
     def sawyer_agent


### PR DESCRIPTION
## Summary
- `request` conditionally appended `next_page` only when `paginate` was true, returning a 2- or 3-element array
- Subclasses (e.g. `Okta::Management::Client`) that destructure with `response, status = super(...)` silently dropped the third element, making `paginate: true` a no-op
- Now always returns `[data, status, next_page]` (with `nil` when not paginating) so subclass overrides propagate the cursor correctly
